### PR TITLE
27 Set the timezone for the advanced example

### DIFF
--- a/examples/advanced/docker_jenkins/Dockerfile
+++ b/examples/advanced/docker_jenkins/Dockerfile
@@ -17,5 +17,5 @@ RUN chown -R jenkins:jenkins /var/casc_configs
 USER jenkins
 ENV CASC_JENKINS_CONFIG /var/casc_configs
 
-# Instruct Jenkins not to run the initial setup wizard
-ENV JAVA_OPTS "-Djenkins.install.runSetupWizard=false ${JAVA_OPTS:-}"
+# Instruct Jenkins not to run the initial setup wizard and to use Eastern time
+ENV JAVA_OPTS "-Duser.timezone=America/New_York -Djenkins.install.runSetupWizard=false ${JAVA_OPTS:-}"


### PR DESCRIPTION
Closes #27 

Demonstrating how to set the timezone for Jenkins.

This isn't entirely aligned with the initial thought for the issue.  The idea was a user could say "build me jenkins, and put it on hawaii time".  
Changing the timezone with JAVA_OPTS is what has worked best for the past few months.  
So I'm going to judge setting the timezone as a custom config, outside the scope of the module itself. 
Setting the timezone is on the end user, if they wish.  It's easy enough to do, and an example is now added.

Going to consider it closed